### PR TITLE
feat: read single account functionality (#2)

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -70,7 +70,24 @@ def create_accounts():
 # READ AN ACCOUNT
 ######################################################################
 
-# ... place you code here to READ an account ...
+@app.route("/accounts/<int:account_id>", methods=["GET"])
+def read_account(account_id):
+    """
+    Reads an Account
+    This endpoint will read a single Account based on the given id
+    """
+    app.logger.info(f"Request to read the Account with id = {account_id}")
+    account = Account.find(account_id)
+
+    if not account:
+        # account does not exits
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Account with id {account_id} doesn't exist"
+        )
+
+    # account found, build and return response
+    return account.serialize(), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -7,6 +7,7 @@ Test cases can be run with the following:
 """
 import os
 import logging
+import random
 from unittest import TestCase
 from tests.factories import AccountFactory
 from service.common import status  # HTTP Status Codes
@@ -126,4 +127,27 @@ class TestAccountService(TestCase):
             status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
         )
 
-    # ADD YOUR TEST CASES HERE ...
+    def test_read_an_account(self):
+        """It should read a single Account"""
+        # create 5 test accounts, select one
+        account = random.choice(self._create_accounts(5))
+
+        # test to successfully read the account
+        response = self.client.get(
+            BASE_URL + f"/{str(account.id)}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # test the data returned
+        data = response.get_json()
+        self.assertEqual(data["id"], account.id)
+        self.assertEqual(data["name"], account.name)
+        self.assertEqual(data["email"], account.email)
+        self.assertEqual(data["address"], account.address)
+        self.assertEqual(data["phone_number"], account.phone_number)
+        self.assertEqual(str(data["date_joined"]), str(account.date_joined))
+
+    def test_read_nonexisting_account(self):
+        """It should fail to read a non-existing Account"""
+        response = self.client.get(BASE_URL + "/123")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
### Description
This PR implements the `GET` method for the `/accounts/<id>` endpoint, allowing the retrieval of specific account details by `ID`.

**Closes** #2 (Read an account from the service)

### Changes
- Added `GET` route for `/accounts/<int:account_id>` in `routes.py`.
- Implemented logic to return `200 OK` with account data or `404 NOT FOUND` if the ID is missing.
- Added unit tests for successful retrieval and non-existing accounts.
- 
### Tests
- [x] All unit tests passed (including the new `test_read_an_account` and `test_read_nonexisting_account`).
- [x] `routes.py` coverage maintained at `100%`.
- [x] Linting (`pylint`, `flake8`) passed with no new violations.