### PR TITLE
feat: read list of accounts functionality (#5)

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -59,11 +59,22 @@ def create_accounts():
         jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
     )
 
+
 ######################################################################
 # LIST ALL ACCOUNTS
 ######################################################################
 
-# ... place you code here to LIST accounts ...
+@app.route("/accounts", methods=["GET"])
+def list_accounts():
+    """
+    Reads the list of Accounts
+    This endpoint will return the list of all Accounts
+    """
+    app.logger.info("Request to read the list of all Accounts")
+    accounts = Account.all()
+
+    # return list of serialized accounts
+    return jsonify([acc.serialize() for acc in accounts]), status.HTTP_200_OK
 
 
 ######################################################################
@@ -74,7 +85,7 @@ def create_accounts():
 def read_account(account_id):
     """
     Reads an Account
-    This endpoint will read a single Account based on the given id
+    This endpoint will return a single Account based on the given id
     """
     app.logger.info(f"Request to read the Account with id = {account_id}")
     account = Account.find(account_id)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,6 +8,7 @@ Test cases can be run with the following:
 import os
 import logging
 import random
+from datetime import date
 from unittest import TestCase
 from tests.factories import AccountFactory
 from service.common import status  # HTTP Status Codes
@@ -151,3 +152,52 @@ class TestAccountService(TestCase):
         """It should fail to read a non-existing Account"""
         response = self.client.get(BASE_URL + "/123")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_list_accounts(self):
+        """It should read the list of Accounts"""
+        # create 5 test accountss
+        account_objects = self._create_accounts(5)
+
+        # test to successfully read the list of accounts
+        response = self.client.get(
+            BASE_URL
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # test the data returned
+        data = response.get_json()
+        for account in data:
+            account_id = account["id"]
+            account_object = next(
+                (acc for acc in account_objects if acc.id == account_id),
+                None
+            )
+            self.assertNotEqual(account_object, None)
+
+            # test if the attributes match
+            self.assertEqual(account["id"], account_object.id)
+            self.assertEqual(account["name"], account_object.name)
+            self.assertEqual(account["email"], account_object.email)
+            self.assertEqual(account["address"], account_object.address)
+            self.assertEqual(
+                account["phone_number"],
+                account_object.phone_number
+            )
+            self.assertEqual(
+                date.fromisoformat(account["date_joined"]),
+                account_object.date_joined
+            )
+
+    def test_list_no_accounts(self):
+        """It should read the empty list of Accounts"""
+        # test to successfully read the empty list of accounts
+        response = self.client.get(
+            BASE_URL
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # check if a list is returned
+        self.assertIsInstance(response.get_json(), list)
+
+        # check if returned list is empty
+        self.assertEqual(len(response.get_json()), 0)


### PR DESCRIPTION
### Description
This PR implements the `GET` method for the `/accounts` endpoint, allowing the retrieval of the list of all accounts.

**Closes** #5 (List all accounts from the service)

### Changes
- Added `GET` route for `/accounts` in `routes.py`.
- Implemented logic to return `200 OK` with account data or empty list in case of no accounts.
- Added unit tests for successful retrieval of accounts list and empty list.

### Tests
- [x] All unit tests passed (including the new `test_list_accounts` and `test_list_no_accounts`).
- [x] `routes.py` coverage maintained at `100%`.
- [x] Linting (`pylint`, `flake8`) passed with no new violations.