### PR TITLE
feat: update account functionality

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -105,7 +105,32 @@ def read_account(account_id):
 # UPDATE AN EXISTING ACCOUNT
 ######################################################################
 
-# ... place you code here to UPDATE an account ...
+@app.route("/accounts/<int:account_id>", methods=["PUT"])
+def update_account(account_id):
+    """
+    Updates an Account
+    This endpoint will update the Account for the account_id with
+    the values of the json in the body
+    """
+    app.logger.info(f"Request to update the Account with id = {account_id}")
+    check_content_type("application/json")
+
+    # try to get the Account from the DB
+    account_object = Account.find(account_id)
+
+    if not account_object:
+        # account does not exits
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Account with id {account_id} doesn't exist"
+        )
+
+    # update the DB object with the new values
+    account_object.deserialize(request.get_json())
+    account_object.update()
+
+    # return the new values
+    return account_object.serialize(), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -201,3 +201,66 @@ class TestAccountService(TestCase):
 
         # check if returned list is empty
         self.assertEqual(len(response.get_json()), 0)
+
+    def test_update_account(self):
+        """It should update an Account"""
+        # create 5 test accounts, select one
+        account = random.choice(self._create_accounts(5))
+
+        # read the account before the update
+        resp_original = self.client.get(
+            BASE_URL + f"/{str(account.id)}"
+        )
+        self.assertEqual(resp_original.status_code, status.HTTP_200_OK)
+        data_original = resp_original.get_json()
+
+        # change the da, a in thsomeccoun and do the update
+        data_changed = data_original.copy()
+        data_changed["name"] = "Test Candidate"
+        data_changed["email"] = "tester@mailtest.org"
+
+        resp_returned = self.client.put(
+            BASE_URL + f"/{str(data_changed['id'])}",
+            json=data_changed,
+            content_type="application/json"
+        )
+        self.assertEqual(resp_returned.status_code, status.HTTP_200_OK)
+        data_returned = resp_returned.get_json()
+
+        # compare the returned and the changed data
+        self.assertEqual(data_returned["name"], data_changed["name"])
+        self.assertEqual(data_returned["email"], data_changed["email"])
+        self.assertEqual(data_returned["address"], data_changed["address"])
+        self.assertEqual(
+            data_returned["phone_number"],
+            data_changed["phone_number"]
+        )
+        self.assertEqual(
+            date.fromisoformat(data_returned["date_joined"]),
+            date.fromisoformat(data_changed["date_joined"])
+        )
+
+        # compare the returned and the original data,
+        # these should be different:
+        self.assertNotEqual(data_returned["name"], data_original["name"])
+        self.assertNotEqual(data_returned["email"], data_original["email"])
+        
+        # these should be the same:
+        self.assertEqual(data_returned["address"], data_original["address"])
+        self.assertEqual(
+            data_returned["phone_number"],
+            data_original["phone_number"]
+        )
+        self.assertEqual(
+            date.fromisoformat(data_returned["date_joined"]),
+            date.fromisoformat(data_original["date_joined"])
+        )
+
+    def test_update_nonexisting_account(self):
+        """It should fail to update a non-existing Account"""
+        test_account = AccountFactory()
+        response = self.client.put(
+            BASE_URL + "/123",
+            json=test_account.serialize()
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
### Description
This PR implements the `PUT` method for the `/accounts` endpoint, allowing the update of an account.

**Closes** #3 (Update an account in the service)

### Changes
- Added `PUT` route for `/accounts/<id>` in `routes.py`.
- Implemented logic to return `200 OK` with the current/updated account data or `404 NOT FOUND` if the ID is not found.
- Added unit tests for successful update and attempt to update a non-existing account.

### Tests
- [x] All unit tests passed (including the new `test_update_account` and `test_update_nonexisting_account`).
- [x] `routes.py` coverage maintained at `100%`.
- [x] Linting (`pylint`, `flake8`) passed with no new violations.