### PR TITLE
feat: delete account functionality

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -137,7 +137,20 @@ def update_account(account_id):
 # DELETE AN ACCOUNT
 ######################################################################
 
-# ... place you code here to DELETE an account ...
+@app.route("/accounts/<int:account_id>", methods=["DELETE"])
+def delete_account(account_id):
+    """
+    Deletes an Account
+    This endpoint will delete the Account for the account_id from the DB
+    """
+    app.logger.info(f"Request to delete the Account with id = {account_id}")
+    account = Account.find(account_id)
+
+    if account:
+        # account found, delete it
+        account.delete()
+
+    return "", status.HTTP_204_NO_CONTENT
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -244,7 +244,7 @@ class TestAccountService(TestCase):
         # these should be different:
         self.assertNotEqual(data_returned["name"], data_original["name"])
         self.assertNotEqual(data_returned["email"], data_original["email"])
-        
+
         # these should be the same:
         self.assertEqual(data_returned["address"], data_original["address"])
         self.assertEqual(
@@ -264,3 +264,27 @@ class TestAccountService(TestCase):
             json=test_account.serialize()
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_account(self):
+        """It should delete an Account"""
+        # create 5 test accounts, select one
+        account = random.choice(self._create_accounts(5))
+
+        # delete the account and check status
+        resp_returned = self.client.delete(
+            BASE_URL + f"/{str(account.id)}"
+        )
+        self.assertEqual(resp_returned.status_code, status.HTTP_204_NO_CONTENT)
+
+        # try to read the account just deleted
+        response_read = self.client.get(
+            BASE_URL + f"/{str(account.id)}"
+        )
+        self.assertEqual(response_read.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_nonexisting_account(self):
+        """It should return NO_CONTENT when deleting a non-existing Account"""
+        resp_returned = self.client.delete(
+            BASE_URL + "/123"
+        )
+        self.assertEqual(resp_returned.status_code, status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### Description
This PR implements the `DELETE` method for the `/accounts` endpoint, allowing to delete an account.

**Closes** #4 (Delete an account from the service)

### Changes
- Added `DELETE` route for `/accounts/<id>` in `routes.py`.
- Implemented logic to return `204 NO_CONTENT` on delete and also when the ID is not found.
- Added unit tests for delete and attempt to delete a non-existing account.

### Tests
- [x] All unit tests passed (including the new `test_delete_account` and `test_delete_nonexisting_account`).
- [x] `routes.py` coverage maintained at `100%`.
- [x] Linting (`pylint`, `flake8`) passed with no new violations.