### PR TITLE
feat: add unit test for HTTP_405_METHOD_NOT_ALLOWED

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -294,3 +294,13 @@ class TestAccountService(TestCase):
             BASE_URL + "/123"
         )
         self.assertEqual(resp_returned.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_method_not_allowed(self):
+        """It should not allow an illegal method call"""
+        response = self.client.delete(
+            BASE_URL
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_405_METHOD_NOT_ALLOWED
+        )


### PR DESCRIPTION
### Description
This PR adds the unit test that tests `method_not_supported()` in `error_handler.py`, boosting the test coverage.

### Changes
- Added `test_method_not_allowed()` in `test_routes.py`.

### Tests
- [x] All unit tests passed (including the new `test_method_not_allowed`).
- [x] `error_handlers.py` coverage increased from `81%` to `91%`.
- [x] Linting (`pylint`, `flake8`) passed with no new violations.