### PR TITLE
feat: add kubernetes support

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: accounts
+  name: accounts
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: accounts
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: accounts
+    spec:
+      containers:
+      - image: us.icr.io/sn-labs-chrrrcrsr/accounts:1
+        name: accounts
+        resources: {}
+
+        env:
+          - name: DATABASE_HOST
+            value: postgresql
+          - name: DATABASE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-name
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-password
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-user
+
+status: {}

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: accounts
+  name: accounts
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: accounts
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
### Description
This PR adds Kubernetes support for the app via the manifest definition files in the folder `deploy`.

**Closes** #7 (Deploy the accounts service Docker image to Kubernetes)

### Changes
- Add `deploy/deployment.yaml` and `deploy/service.yaml`.
- uses proper secrets/env var handling for the PostgreSQL credentials.
- service declares 3 replicas.

### Manual Validation
- [x] Scenario "Deployment of the accounts API to OpenShift"
- [x] Scenario "Deployment of the accounts API to Kubernetes"
- [x] Scenario "Test replicas of the accounts API to Kubernetes"
- [x] pylint/flake8/nosetests