### PR TITLE
Cd pipeline

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: accounts
     spec:
       containers:
-      - image: us.icr.io/sn-labs-chrrrcrsr/accounts:1
+      - image: IMAGE_NAME_HERE
         name: accounts
         resources: {}
 

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -79,3 +79,22 @@ spec:
       runAfter:
         - lint
         - tests
+
+    - name: deploy
+      workspaces:
+        - name: manifest-dir
+          workspace: pipeline-workspace
+      taskRef:
+        name: openshift-client
+        kind: ClusterTask
+      params:
+      - name: SCRIPT
+        value: |
+          echo "Updating manifest..."
+          sed -i "s|IMAGE_NAME_HERE|$(params.build-image)|g" deploy/deployment.yaml
+          cat deploy/deployment.yaml
+          echo "Deploying to OpenShift..."
+          oc apply -f deploy/
+          oc get pods -l app=accounts
+      runAfter:
+        - build

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -36,3 +36,17 @@ spec:
         value: $(params.branch)
       runAfter:
         - init
+
+    - name: lint
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      taskRef:
+        name: flake8
+      params:
+      - name: image
+        value: "python:3.9-slim"
+      - name: args
+        value: ["--count", "--max-complexity=10", "--max-line-length=127", "--statistics"]
+      runAfter:
+        - clone

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -15,6 +15,7 @@ spec:
     - name: repo-url
     - name: branch
       default: main
+    - name: build-image
   tasks:
     - name: init
       workspaces:
@@ -51,16 +52,30 @@ spec:
       runAfter:
         - clone
 
-    - name: nose
+    - name: tests
       workspaces:
         - name: source
           workspace: pipeline-workspace
       taskRef:
         name: nose
       params:
-      - name: image
-        value: "python:3.9-slim"
+      - name: database_uri
+        value: "sqlite:///test.db"
       - name: args
         value: "-v --with-spec --spec-color"
       runAfter:
         - clone
+
+    - name: build
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      taskRef:
+        name: buildah
+        kind: ClusterTask
+      params:
+      - name: IMAGE
+        value: "$(params.build-image)"
+      runAfter:
+        - lint
+        - tests

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -50,3 +50,17 @@ spec:
         value: ["--count", "--max-complexity=10", "--max-line-length=127", "--statistics"]
       runAfter:
         - clone
+
+    - name: nose
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      taskRef:
+        name: nose
+      params:
+      - name: image
+        value: "python:3.9-slim"
+      - name: args
+        value: "-v --with-spec --spec-color"
+      runAfter:
+        - clone

--- a/tekton/tasks.yaml
+++ b/tekton/tasks.yaml
@@ -49,4 +49,36 @@ spec:
           # Delete files and directories starting with .. plus any other character
           rm -rf "${WORKSPACE_SOURCE_PATH}"/..?*
         fi
-
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: nose
+spec:
+  description: This task will run nosetests on the provided input.
+  workspaces:
+    - name: source
+  params:
+    - name: args
+      description: The args that get passed to nosetests
+      type: string
+      default: "-v"
+    - name: database_uri
+      description: Database connection string to use
+      type: string
+      default: "sqlite:///test.db"
+  steps:
+    - name: nosetests
+      image: python:3.9-slim
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: DATABASE_URI
+          value: $(params.database_uri)
+      script: |
+        #!/bin/bash
+        set -e
+        echo "***** Installing dependencies *****"
+        python -m pip install --upgrade pip wheel
+        pip install -qr requirements.txt
+        echo "***** Running nosetests with: $(params.args)"
+        nosetests $(params.args)


### PR DESCRIPTION
### Description
This PR adds the full `tekton` CD Pipeline, which includes cloning, linting, test, building and deployment.

**Closes** #19 (Create a CD pipeline to automate deployment to Kubernetes)

### Changes
- Add placeholder for image to deploy in `deploy/deployment.yaml`.
- Add custom `nose` Task to `tekton/tasks.yaml` to run `nosetests`.
- Add the following CD Pipeline steps to `tekton/pipeline.yaml`:
- `lint` (`flake8`)
- `tests `(`nosetest`)
- `build` (`buildah`)
- `deploy` (`openshift-client`)

### Manual Validation
- [x] Deployment via CD Pipeline